### PR TITLE
Add getters for Observatory URLs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.2.3
+
+* Add `VMIsolate.observatoryUrl` and `VMObjectRef.observatoryUrl` getters that
+  provide access to human-friendly relative Observatory URLs for VM service objects.
+
 ## 0.2.2+4
 
 * Fix a bug where `Isolate.invokeExtension()` would fail if the extension method

--- a/lib/src/breakpoint.dart
+++ b/lib/src/breakpoint.dart
@@ -50,6 +50,8 @@ class VMBreakpoint extends VMObject {
   /// instance objects that refer to the same breakpoint.
   final bool _fixedId;
 
+  Uri get observatoryUrl => _scope.observatoryUrlFor(_id);
+
   final int size;
 
   final VMClassRef klass;

--- a/lib/src/class.dart
+++ b/lib/src/class.dart
@@ -31,6 +31,8 @@ class VMClassRef implements VMObjectRef {
   /// objects that refer to the same class.
   final bool _fixedId;
 
+  Uri get observatoryUrl => _scope.observatoryUrlFor(_id);
+
   /// The name of this class.
   final String name;
 

--- a/lib/src/code.dart
+++ b/lib/src/code.dart
@@ -25,6 +25,8 @@ class VMCodeRef implements VMObjectRef {
   /// objects that refer to the same code.
   final bool _fixedId;
 
+  Uri get observatoryUrl => _scope.observatoryUrlFor(_id);
+
   /// This code's name.
   final String name;
 

--- a/lib/src/context.dart
+++ b/lib/src/context.dart
@@ -26,6 +26,8 @@ class VMContextRef implements VMObjectRef {
   /// context objects that refer to the same context.
   final bool _fixedId;
 
+  Uri get observatoryUrl => _scope.observatoryUrlFor(_id);
+
   /// The number of variables in this context.
   final int length;
 

--- a/lib/src/error.dart
+++ b/lib/src/error.dart
@@ -34,6 +34,8 @@ class VMErrorRef implements VMObjectRef {
   /// objects that refer to the same error.
   final bool _fixedId;
 
+  Uri get observatoryUrl => _scope.observatoryUrlFor(_id);
+
   /// The kind of error this is.
   final VMErrorKind kind;
 

--- a/lib/src/field.dart
+++ b/lib/src/field.dart
@@ -28,6 +28,8 @@ class VMFieldRef implements VMObjectRef {
   /// objects that refer to the same field.
   final bool _fixedId;
 
+  Uri get observatoryUrl => _scope.observatoryUrlFor(_id);
+
   /// The name of this field.
   final String name;
 

--- a/lib/src/function.dart
+++ b/lib/src/function.dart
@@ -31,6 +31,8 @@ class VMFunctionRef implements VMObjectRef {
   /// function objects that refer to the same function.
   final bool _fixedId;
 
+  Uri get observatoryUrl => _scope.observatoryUrlFor(_id);
+
   /// The name of this function.
   final String name;
 

--- a/lib/src/instance.dart
+++ b/lib/src/instance.dart
@@ -167,6 +167,8 @@ class VMInstanceRef implements VMObjectRef {
   /// instance objects that refer to the same instance.
   final bool _fixedId;
 
+  Uri get observatoryUrl => _scope.observatoryUrlFor(_id);
+
   final VMClassRef klass;
 
   VMInstanceRef._(Scope scope, Map json)

--- a/lib/src/isolate.dart
+++ b/lib/src/isolate.dart
@@ -50,6 +50,15 @@ class VMIsolateRef {
   /// This isn't guaranteed to be unique. It can be set using [setName].
   final String name;
 
+  /// A *relative* URL for humans to inspect and interact with this isolate in
+  /// the Observatory UI.
+  ///
+  /// Because the VM service client doesn't always know the full location of the
+  /// Observatory UI, this needs to be resolved against the absolute URL of the
+  /// Observatory UI in order to be usable.
+  Uri get observatoryUrl => Uri.parse(
+      "#/inspect?isolateId=${Uri.encodeQueryComponent(_scope.isolateId)}");
+
   /// A broadcast stream that emits a `null` value every time a garbage
   /// collection occurs in this isolate.
   Stream get onGC => _onGC;

--- a/lib/src/library.dart
+++ b/lib/src/library.dart
@@ -30,6 +30,8 @@ class VMLibraryRef implements VMObjectRef {
   /// library objects that refer to the same library.
   final bool _fixedId;
 
+  Uri get observatoryUrl => _scope.observatoryUrlFor(_id);
+
   /// The name of this library, derived from its library tag.
   final String name;
 

--- a/lib/src/object.dart
+++ b/lib/src/object.dart
@@ -16,6 +16,17 @@ import 'class.dart';
 /// Most objects will have only a subset of their information available as a
 /// reference, and must be [load]ed to retrieve their full information.
 abstract class VMObjectRef {
+  /// A *relative* URL for humans to inspect and possibly interact with this
+  /// object in the Observatory UI.
+  ///
+  /// Because the VM service client doesn't always know the full location of the
+  /// Observatory UI, this needs to be resolved against the absolute URL of the
+  /// Observatory UI in order to be usable.
+  ///
+  /// Note that the Observatory may not have useful UI components for all
+  /// possible object types.
+  Uri get observatoryUrl;
+
   /// Loads a full version of this object.
   ///
   /// This will throw a [VMSentinelException] if this object is no longer

--- a/lib/src/scope.dart
+++ b/lib/src/scope.dart
@@ -28,6 +28,12 @@ class Scope {
 
   Scope(this.peer, this.streams, this.isolateId);
 
+  /// Returns the [VMObjectRef.observatoryUrl] for an object with the given
+  /// [id].
+  Uri observatoryUrlFor(String id) => Uri.parse(
+      "#/inspect?isolateId=${Uri.encodeQueryComponent(isolateId)}&"
+        "objectId=${Uri.encodeQueryComponent(id)}");
+
   /// Given the ID for a [VMObjectRef], loads the JSON for its corresponding
   /// [VMObject].
   ///

--- a/lib/src/script.dart
+++ b/lib/src/script.dart
@@ -49,6 +49,8 @@ class VMScriptRef implements VMObjectRef {
   /// script objects that refer to the same script.
   final bool _fixedId;
 
+  Uri get observatoryUrl => _scope.observatoryUrlFor(_id);
+
   /// The URI from which this script was loaded.
   final Uri uri;
 

--- a/lib/src/type_arguments.dart
+++ b/lib/src/type_arguments.dart
@@ -28,6 +28,8 @@ class VMTypeArgumentsRef implements VMObjectRef {
   /// arguments objects that refer to the same type arguments.
   final bool _fixedId;
 
+  Uri get observatoryUrl => _scope.observatoryUrlFor(_id);
+
   /// A name for this type argument list.
   final String name;
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: vm_service_client
-version: 0.2.2+4
+version: 0.2.3
 description: A client for the Dart VM service.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/vm_service_client


### PR DESCRIPTION
These make it easier for people to provide useful URLs to end users.