### PR TITLE
Bump async constraints to allow 2.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
   sdk: '>=1.21.0 <2.0.0'
 
 dependencies:
-  async: '^1.7.0'
+  async: '>=1.7.0 <3.0.0'
   collection: '^1.5.0'
   json_rpc_2: '^2.0.0'
   pub_semver: '^1.0.0'


### PR DESCRIPTION
According to the [async changelog](https://pub.dartlang.org/packages/async#-changelog-tab-), only a few breaking changes occurred in async 2.0.0, and vm_service_client appears to not interact with anything that changed:

```none
$ git grep result.dart
$ git grep stream_zip.dart
$ git grep ReleaseStream
$ git grep CaptureStream
$ git grep ErrorResult
$
```