### PR TITLE
Add VMStep.OverAsyncSuspension and atAsyncSuspension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.2.5+2
+## 0.2.6
 
 * Add `VMPauseEvent.atAsyncSuspension` to indicate when an isolate is paused at an
   await, yield, or yield* statement (only available from VM service version 3.3).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.2.5+2
+
+* Add `VMPauseEvent.atAsyncSuspension` to indicate when an isolate is paused at an
+  await, yield, or yield* statement.
+* Add `VMStep.OverAsyncSuspension` to allow continuing until execution returns from
+  an await, yield, or yield* statement.
+
 ## 0.2.5+1
 
 * Support Dart 2 stable releases.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 ## 0.2.5+2
 
 * Add `VMPauseEvent.atAsyncSuspension` to indicate when an isolate is paused at an
-  await, yield, or yield* statement.
+  await, yield, or yield* statement (only available from VM service version 3.3).
 * Add `VMStep.OverAsyncSuspension` to allow continuing until execution returns from
-  an await, yield, or yield* statement.
+  an await, yield, or yield* statement (only valid when
+  `VMPauseEvent.atAsyncSuspension` is `true`).
 
 ## 0.2.5+1
 

--- a/lib/src/isolate.dart
+++ b/lib/src/isolate.dart
@@ -492,6 +492,9 @@ class VMStep {
   /// The isolate takes a single step, skipping over function calls.
   static const over = const VMStep._("Over");
 
+  /// The isolate continues until the Future being awaited completes.
+  static const overAsyncSuspension = const VMStep._("OverAsyncSuspension");
+
   /// The isolate continues until it exits the current function.
   static const out = const VMStep._("Out");
 

--- a/lib/src/isolate.dart
+++ b/lib/src/isolate.dart
@@ -492,7 +492,8 @@ class VMStep {
   /// The isolate takes a single step, skipping over function calls.
   static const over = const VMStep._("Over");
 
-  /// The isolate continues until the Future being awaited completes.
+  /// The isolate continues until the execution returns from the an await, yield,
+  /// or yield* statement. Valid when [VMPauseEvent.atAsyncSuspension] is true.
   static const overAsyncSuspension = const VMStep._("OverAsyncSuspension");
 
   /// The isolate continues until it exits the current function.

--- a/lib/src/isolate.dart
+++ b/lib/src/isolate.dart
@@ -493,7 +493,10 @@ class VMStep {
   static const over = const VMStep._("Over");
 
   /// The isolate continues until the execution returns from the an await, yield,
-  /// or yield* statement. Valid when [VMPauseEvent.atAsyncSuspension] is true.
+  /// or yield* statement.
+  ///
+  /// Note that this value is only valid from VM service version 3.3 and when
+  /// [VMPauseEvent.atAsyncSuspension] is true.
   static const overAsyncSuspension = const VMStep._("OverAsyncSuspension");
 
   /// The isolate continues until it exits the current function.

--- a/lib/src/pause_event.dart
+++ b/lib/src/pause_event.dart
@@ -33,7 +33,7 @@ VMPauseEvent newVMPauseEvent(Scope scope, Map json) {
 
 /// An event indicating that an isolate has been paused or resumed.
 abstract class VMPauseEvent {
-  /// Is the isolate paused at an await, yield, or yield* statement?
+  /// Whether the isolate is paused at an await, yield, or yield* statement
   ///
   /// This is provided for the event kinds:
   ///   PauseBreakpoint

--- a/lib/src/pause_event.dart
+++ b/lib/src/pause_event.dart
@@ -33,6 +33,13 @@ VMPauseEvent newVMPauseEvent(Scope scope, Map json) {
 
 /// An event indicating that an isolate has been paused or resumed.
 abstract class VMPauseEvent {
+  /// Is the isolate paused at an await, yield, or yield* statement?
+  ///
+  /// This is provided for the event kinds:
+  ///   PauseBreakpoint
+  ///   PauseInterrupted
+  final bool atAsyncSuspension;
+
   /// The top stack frame associated with this event.
   ///
   /// This is `null` for [VMPauseInterruptedEvent]s when the interrupt arrived
@@ -47,7 +54,8 @@ abstract class VMPauseEvent {
   final DateTime time;
 
   VMPauseEvent._(Scope scope, Map json)
-      : topFrame = newVMFrame(scope, json["frame"]),
+      : atAsyncSuspension = json["atAsyncSuspension"],
+        topFrame = newVMFrame(scope, json["frame"]),
         time = json["timestamp"] == null
             ? null
             : new DateTime.fromMillisecondsSinceEpoch(json["timestamp"]);

--- a/lib/src/pause_event.dart
+++ b/lib/src/pause_event.dart
@@ -35,7 +35,8 @@ VMPauseEvent newVMPauseEvent(Scope scope, Map json) {
 abstract class VMPauseEvent {
   /// Whether the isolate is paused at an await, yield, or yield* statement
   ///
-  /// This is provided for the event kinds:
+  /// This is only available from VM service version 3.3 and only provided for
+  /// the event kinds:
   ///   PauseBreakpoint
   ///   PauseInterrupted
   final bool atAsyncSuspension;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: vm_service_client
-version: 0.2.5+1
+version: 0.2.5+2
 description: A client for the Dart VM service.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/vm_service_client

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: vm_service_client
-version: 0.2.5+2
+version: 0.2.6
 description: A client for the Dart VM service.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/vm_service_client

--- a/test/isolate_test.dart
+++ b/test/isolate_test.dart
@@ -455,7 +455,8 @@ void main() {
       stdout = new StreamQueue(isolate.stdout.transform(lines));
     });
 
-    test("steps over the async suspension with VMStep.overAsyncSuspension", () async {
+    test("steps over the async suspension with VMStep.overAsyncSuspension",
+        () async {
       // Step from the `debugger` statement to the await line.
       await isolate.resume(step: VMStep.over);
       await isolate.waitUntilPaused();
@@ -471,7 +472,8 @@ void main() {
       frame = (await isolate.getStack()).frames.first;
       expect(await sourceLine(frame.location), equals(10));
 
-      expect((await isolate.load()).pauseEvent.atAsyncSuspension, isNot(equals(true)));
+      expect((await isolate.load()).pauseEvent.atAsyncSuspension,
+          isNot(equals(true)));
     });
   });
 

--- a/test/isolate_test.dart
+++ b/test/isolate_test.dart
@@ -430,6 +430,51 @@ void main() {
     });
   });
 
+  group("resume(overAsyncSuspension)", () {
+    var isolate;
+    var stdout;
+    setUp(() async {
+      client = await runAndConnect(topLevel: r"""
+        inner() {
+          print("in inner");
+          return new Future.delayed(const Duration(milliseconds: 1));
+        }
+
+        outer() async {
+          debugger();
+          await inner(); // line 9
+          print("after inner"); // line 10
+        }
+      """, main: r"""
+        await outer();
+        print("after outer");
+      """);
+
+      isolate = (await client.getVM()).isolates.first;
+      await isolate.waitUntilPaused();
+      stdout = new StreamQueue(isolate.stdout.transform(lines));
+    });
+
+    test("steps over the async suspension with VMStep.overAsyncSuspension", () async {
+      // Step from the `debugger` statement to the await line.
+      await isolate.resume(step: VMStep.over);
+      await isolate.waitUntilPaused();
+
+      var frame = (await isolate.getStack()).frames.first;
+      expect(await sourceLine(frame.location), equals(9));
+
+      expect((await isolate.load()).pauseEvent.atAsyncSuspension, equals(true));
+
+      await isolate.resume(step: VMStep.overAsyncSuspension);
+      await isolate.waitUntilPaused();
+
+      frame = (await isolate.getStack()).frames.first;
+      expect(await sourceLine(frame.location), equals(10));
+
+      expect((await isolate.load()).pauseEvent.atAsyncSuspension, isNot(equals(true)));
+    });
+  });
+
   test("setName() sets the isolate's name", () async {
     client = await runAndConnect(flags: ['--pause-isolates-on-start']);
 


### PR DESCRIPTION
This fixes #30 and #31.

I used the `Over` test as a template and just made it async; let me know if I can do better. I wasn't totally sure what this code was doing in the `Over` test:

```
stdout.next.then(neverCalled).catchError((_) {});
```

So I didn't include it. It seems like it'll throw on the next output, but then swallow the error; but that seems pointless. LMK what it's actually doing and whether I should have something similar.

I had to do this work against a slightly older SDK (I used v2 dev40) because the tests all time out in the newest versions and I couldn't totally figure out why. I can't see any obvious CI set up here so if it's building somewhere and this fails (I don't expect it to, it passes locally) let me know.