### PR TITLE
Allow stream_channel version 2.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.6+1
+
+* Allow `stream_channel` version 2.x
+
 ## 0.2.6
 
 * Add `VMPauseEvent.atAsyncSuspension` to indicate when an isolate is paused at an

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,21 +1,21 @@
 name: vm_service_client
-version: 0.2.6
+version: 0.2.6+1
 description: A client for the Dart VM service.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/vm_service_client
 
 environment:
-  sdk: '>=2.0.0-dev.58.0 <3.0.0'
+  sdk: ">=2.0.0 <3.0.0"
 
 dependencies:
-  async: '>=1.7.0 <3.0.0'
-  collection: '^1.5.0'
-  json_rpc_2: '^2.0.0'
-  pub_semver: '^1.0.0'
-  source_span: '^1.4.0'
-  stack_trace: '^1.5.0'
-  stream_channel: '^1.1.0'
-  web_socket_channel: '^1.0.0'
+  async: ^2.0.0
+  collection: ^1.5.0
+  json_rpc_2: ^2.0.0
+  pub_semver: ^1.0.0
+  source_span: ^1.4.0
+  stack_trace: ^1.5.0
+  stream_channel: ">=1.1.0 <3.0.0"
+  web_socket_channel: ^1.0.0
 
 dev_dependencies:
   test: ^1.2.0


### PR DESCRIPTION
None of the planned breaking changes will impact this package.

- Fix constraint style.
- Remove lower bound on `async` since 1.x is not Dart 2 compatible
  anyway.