### PR TITLE
Fix some analyzer warnings

### DIFF
--- a/lib/src/instance.dart
+++ b/lib/src/instance.dart
@@ -7,7 +7,6 @@ import 'dart:collection';
 import 'dart:convert';
 import 'dart:typed_data';
 
-import 'package:async/async.dart';
 import 'package:stack_trace/stack_trace.dart';
 
 import 'bound_field.dart';
@@ -299,7 +298,7 @@ abstract class VMValueInstanceRef<T> extends VMInstanceRef {
   Future<VMValueInstance<T>> load();
 
   Future<T> getValue({onUnknownValue(value)}) =>
-      DelegatingFuture.typed(super.getValue(onUnknownValue: onUnknownValue));
+      super.getValue(onUnknownValue: onUnknownValue).then((v) => v as T);
 
   Future<T> _getValue(onUnknownValue(value)) async => value;
 

--- a/lib/src/isolate.dart
+++ b/lib/src/isolate.dart
@@ -484,7 +484,8 @@ class VMRunnableIsolate extends VMIsolate {
 
   Future<VMRunnableIsolate> loadRunnable() => load();
 
-  Future<VMRunnableIsolate> load() => DelegatingFuture.typed(super.load());
+  Future<VMRunnableIsolate> load() =>
+      super.load().then((v) => v as VMRunnableIsolate);
 
   String toString() => "Isolate running $rootLibrary";
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,4 +18,4 @@ dependencies:
   web_socket_channel: ^1.0.0
 
 dev_dependencies:
-  test: ^1.2.0
+  test: ^1.6.0

--- a/test/exception_handling_test.dart
+++ b/test/exception_handling_test.dart
@@ -27,8 +27,7 @@ void main() {
 
     await isolate.resume();
     await isolate.waitUntilPaused();
-    expect((await isolate.load()).pauseEvent,
-        new isInstanceOf<VMPauseExitEvent>());
+    expect((await isolate.load()).pauseEvent, isA<VMPauseExitEvent>());
   });
 
   test("unhandled pauses only on unhandled exceptions", () async {
@@ -58,8 +57,7 @@ void main() {
     // Resume and expect termination.
     await isolate.resume();
     await isolate.waitUntilPaused();
-    expect((await isolate.load()).pauseEvent,
-        new isInstanceOf<VMPauseExitEvent>());
+    expect((await isolate.load()).pauseEvent, isA<VMPauseExitEvent>());
   });
 
   test("all pauses only on all exceptions", () async {
@@ -95,8 +93,7 @@ void main() {
     // Resume and expect termination.
     await isolate.resume();
     await isolate.waitUntilPaused();
-    expect((await isolate.load()).pauseEvent,
-        new isInstanceOf<VMPauseExitEvent>());
+    expect((await isolate.load()).pauseEvent, isA<VMPauseExitEvent>());
   });
 
   test("exception mode can be read and set", () async {

--- a/test/isolate_test.dart
+++ b/test/isolate_test.dart
@@ -172,6 +172,7 @@ void main() {
         }
 
         // Note: this produces a bogus dead code warning (sdk#30243).
+        // ignore: dead_code
         expect(other.onExit, completes);
       }, skip: "broken by sdk#28505");
     });
@@ -431,8 +432,7 @@ void main() {
   });
 
   group("resume(overAsyncSuspension)", () {
-    var isolate;
-    var stdout;
+    VMIsolateRef isolate;
     setUp(() async {
       client = await runAndConnect(topLevel: r"""
         inner() {
@@ -452,7 +452,6 @@ void main() {
 
       isolate = (await client.getVM()).isolates.first;
       await isolate.waitUntilPaused();
-      stdout = new StreamQueue(isolate.stdout.transform(lines));
     });
 
     test("steps over the async suspension with VMStep.overAsyncSuspension",


### PR DESCRIPTION
The `dead_code` ignore is required and was added internally but never
synced back out to github.

The other changes clean up some other analyzer warnings for deprecated
utilities or unused variables.