### PR TITLE
Support 2.3 paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.2.6+2
+
+* Do not override path during `VMServiceClient.connect`.
+  * Fixes issues with connecting to Dart `2.3` observatory URIs.
+
 ## 0.2.6+1
 
 * Allow `stream_channel` version 2.x

--- a/lib/vm_service_client.dart
+++ b/lib/vm_service_client.dart
@@ -109,7 +109,10 @@ class VMServiceClient {
     }
 
     var uri = url is String ? Uri.parse(url) : url;
-    if (uri.scheme == 'http') uri = uri.replace(scheme: 'ws', path: '/ws');
+    if (uri.scheme == 'http') {
+      var path = uri.path.endsWith('/') ? uri.path : uri.path + '/';
+      uri = uri.replace(scheme: 'ws', path: '${path}ws');
+    }
 
     // TODO(nweiz): Just use [WebSocketChannel.connect] when cross-platform
     // libraries work.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: vm_service_client
-version: 0.2.6+1
+version: 0.2.6+2
 description: A client for the Dart VM service.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/vm_service_client


### PR DESCRIPTION
Dart 2.3 uses a secret token to prevent unauthorized observatory access. The client shouldn't bash over these tokens contained in the path.